### PR TITLE
update firefox and gecko driver

### DIFF
--- a/webapp-dockerfile
+++ b/webapp-dockerfile
@@ -19,14 +19,14 @@ RUN apt-get install -y wget \
         build-essential \
         libgl1-mesa-glx \
         libgtk-3-dev 
-ARG FIREFOX_VERSION=58.0.2
+ARG FIREFOX_VERSION=99.0.1
 RUN wget --no-verbose -O /tmp/firefox.tar.bz2 https://download-installer.cdn.mozilla.net/pub/firefox/releases/$FIREFOX_VERSION/linux-x86_64/en-US/firefox-$FIREFOX_VERSION.tar.bz2 \
    && rm -rf /opt/firefox \
    && tar -C /opt -xjf /tmp/firefox.tar.bz2 \
    && rm /tmp/firefox.tar.bz2 \
    && mv /opt/firefox /opt/firefox-$FIREFOX_VERSION \
    && ln -fs /opt/firefox-$FIREFOX_VERSION/firefox /usr/bin/firefox
-ARG GK_VERSION=v0.19.1
+ARG GK_VERSION=v0.31.0
 RUN wget --no-verbose -O /tmp/geckodriver.tar.gz http://github.com/mozilla/geckodriver/releases/download/$GK_VERSION/geckodriver-$GK_VERSION-linux64.tar.gz \
    && rm -rf /opt/geckodriver \
    && tar -C /opt -zxf /tmp/geckodriver.tar.gz \


### PR DESCRIPTION
The jenkins build is failing currently because of the older version of firefox and geckodriver.